### PR TITLE
https://github.com/AdguardTeam/ExtendedCss/issues/28

### DIFF
--- a/lib/dom-observer.js
+++ b/lib/dom-observer.js
@@ -82,18 +82,13 @@ var DomObserver = (function() { // jshint ignore:line
      * @param callback Callback method to be called when anything has changed
      */
     var observeDom = function(callback) {
-        if (!document.body) {
-            // Do nothing if there is no body
-            return;
-        }
-
         if (MutationObserver) {
             domMutationObserver = new MutationObserver(function(mutations) {
                 if (mutations && mutations.length) {
                     callback();
                 }
             });
-            domMutationObserver.observe(document.body, { 
+            domMutationObserver.observe(document.documentElement, {
                 childList: true,
                 subtree: true,
                 attributes: false
@@ -118,15 +113,7 @@ var DomObserver = (function() { // jshint ignore:line
 
     // EXPOSE
     return {
-        observeDom: function(callback) {
-            if (!document.body) {
-                document.addEventListener('DOMContentLoaded', function() {
-                    observeDom(callback);
-                });
-            } else {
-                observeDom(callback);
-            }
-        },
+        observeDom: observeDom,
         disconnectDom: disconnectDom,
         protectAttribute: protectAttribute 
     };

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -40,7 +40,7 @@ QUnit.test("Case 2. :contains performance", function(assert) {
 });
 
 QUnit.test("Case 3. :matches-css performance", function(assert) {
-    var selectorText = ".container #case3 div div:matches-css(background: about:blank)";
+    var selectorText = ".container #case3 div div:matches-css(background-image: about:blank)";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });


### PR DESCRIPTION
MutationObservers are notified of dom changes during the document initialization step, in particular a creation of `body` is recorded.

It can be tested by using
https://github.com/w3c/web-platform-tests/blob/master/dom/nodes/MutationObserver-document.html
There was a website where the above is hosted, but I can't remember now. (edit - it is at http://w3c-test.org/dom/nodes/MutationObserver-document.html, you can check if a test named 'parser insertion mutations' passes)

I am unsure of its impact on websites' startup phase. There are a lot of mutations during the initialization step, more than those after `DOMContentLoaded`, so it may have nontrivial impact on performance. Current unit tests about performance do not test it. It needed to be tested on some websites known to be heavy for ExtCss about whether this change causes extra loads.
+ Modified a unit test on performance because `background` shorthand property was empty on Edge on FF 54 on my end.