### PR TITLE
Support :-abp-has(), :-abp-has-text()

### DIFF
--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -39,8 +39,8 @@ var ExtendedSelector = (function () { // jshint ignore:line
     // Add :matches-css-*() support
     StylePropertyMatcher.extendSizzle(Sizzle);
 
-    // Add :contains, :has-text support
-    Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.createPseudo(function( text ) {
+    // Add :contains, :has-text, :-abp-has-text support
+    Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["-abp-has-text"] = Sizzle.selectors.createPseudo(function( text ) {
         if(/^\s*\/.*\/\s*$/.test(text)) {
             text = text.trim().slice(1, -1).replace(/\\([\\"])/g, '$1');
             var regex;
@@ -59,6 +59,9 @@ var ExtendedSelector = (function () { // jshint ignore:line
             };
         }
     });
+
+    // Add :-abp-has support
+    Sizzle.selectors.pseudos["-abp-has"] = Sizzle.selectors.pseudos["has"];
 
     /**
      * Complex replacement function. 
@@ -235,7 +238,7 @@ var ExtendedSelector = (function () { // jshint ignore:line
         try {
             // Prepare selector to be compiled with Sizzle
             // Which means transform [-ext-*=""] attributes to pseudo classes
-            var re = /\[-(?:abp|ext)-([a-z-_]+)=(["'])((?:(?=(\\?))\4.)*?)\2\]/g;
+            var re = /\[-ext-([a-z-_]+)=(["'])((?:(?=(\\?))\4.)*?)\2\]/g;
             var str = selectorText.replace(re, evaluateMatch);
 
             // Sizzle's parsing of pseudo class arguments is buggy on certain circumstances

--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -39,8 +39,8 @@ var ExtendedSelector = (function () { // jshint ignore:line
     // Add :matches-css-*() support
     StylePropertyMatcher.extendSizzle(Sizzle);
 
-    // Add :contains, :has-text, :-abp-has-text support
-    Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["-abp-has-text"] = Sizzle.selectors.createPseudo(function( text ) {
+    // Add :contains, :has-text, :-abp-contains support
+    Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["-abp-contains"] = Sizzle.selectors.createPseudo(function( text ) {
         if(/^\s*\/.*\/\s*$/.test(text)) {
             text = text.trim().slice(1, -1).replace(/\\([\\"])/g, '$1');
             var regex;

--- a/test/extended-css/test-extended-css.html
+++ b/test/extended-css/test-extended-css.html
@@ -23,8 +23,6 @@
     #case8>div[-ext-has=":matches-css-before(content: *block me*)"] { display: none; } 
     #case9>div[-ext-contains="Another text"] { font-size: 16px; }
     #case10>div[-ext-contains="Block this"] { display: none; }
-    #case11>div[-abp-has=".banner"] { display:none !important; }
-    #case12 div[-abp-has=".banner:has-text(Banner)"] { display: none; }
   </style>
 
   <style type="text/css">
@@ -82,21 +80,6 @@
     </div>
     <div id="case10">
       <div id="case10-blocked">Block this</div>
-    </div>
-    <div id="case11">
-      <div id="case11-blocked">
-        <div class="banner"></div>
-      </div>
-    </div>
-    <div id="case12">
-      <div id="case12-root">
-        <div id="case12-blocked">
-          <div class="banner">Banner</div>
-        </div>
-        <div id="case12-notblocked">
-          <div class="banner">Another text</div>
-        </div>
-      </div>
     </div>
 
     <script src="../qunit/qunit-2.0.1.js"></script>

--- a/test/extended-css/test-extended-css.js
+++ b/test/extended-css/test-extended-css.js
@@ -146,12 +146,3 @@ QUnit.test("Test attribute protection", function(assert) {
         }, 100);
     }, 100);
 });
-
-QUnit.test("Modifier -abp-has", function(assert) {
-    assertElementStyle("case11-blocked", { display: "none" }, assert);
-});
-
-QUnit.test("Modifier -abp-has with :has-text", function(assert) {
-    assertElementStyle("case12-blocked", { "display": "none" }, assert);
-    assertElementStyle("case12-notblocked", { "display": "" }, assert);
-});

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -192,7 +192,7 @@ QUnit.test( "Test -abp-has and -abp-has-text", function(assert) {
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));
 
-    selector = new ExtendedSelector('div:-abp-has(div.test-class-two) > .test-class:-abp-has-text(adg-test)');
+    selector = new ExtendedSelector('div:-abp-has(div.test-class-two) > .test-class:-abp-contains(adg-test)');
     elements = selector.querySelectorAll();
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -182,3 +182,18 @@ QUnit.test( "Test simple regex support in :matches-css, when ()[] characters are
     var elements = selector.querySelectorAll();
     assert.equal(1, elements.length);
 });
+
+QUnit.test( "Test -abp-has and -abp-has-text", function(assert) {
+    var elements;
+    var selector;
+
+    selector = new ExtendedSelector('div.test-class:-abp-has(time.g-time)');
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+
+    selector = new ExtendedSelector('div:-abp-has(div.test-class-two) > .test-class:-abp-has-text(adg-test)');
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+});


### PR DESCRIPTION
 - Add `:-abp-has()`, `:-abp-has-text()` pseudo classes declarations
 - Do not convert `[-abp-has=".."]` to `:has(..)`