### PR TITLE
Fix sibling combinator splitting

### DIFF
--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -112,7 +112,8 @@ var ExtendedSelector = (function () { // jshint ignore:line
      * Checks if specified token is parenthesis relation
      */
     var isRelationToken = function(token) {
-        return token.type === " " || token.type === ">";
+        var type = token.type;
+        return type === " " || type === ">" || type === '+' || type === '~';
     };
 
     /**
@@ -284,23 +285,58 @@ var ExtendedSelector = (function () { // jshint ignore:line
         if (!simpleNodes || !simpleNodes.length) {
             return resultNodes;
         }
-
         var iSimpleNodes = simpleNodes.length;
-        while (iSimpleNodes--) {
-            var node = simpleNodes[iSimpleNodes];
-            var childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-            if (compiledSelector.relation === ">") {
-                // Filter direct children
-                var iChildNodes = childNodes.length;
-                while (iChildNodes--) {
-                    var childNode = childNodes[iChildNodes];
-                    if (childNode.parentNode === node) {
-                        resultNodes.push(childNode);
+        var node, childNodes, iChildNodes, childNode, parentNode;
+        switch (compiledSelector.relation) {
+            case " ":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
+                    Array.prototype.push.apply(resultNodes, childNodes);
+                }
+                break;
+            case ">":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.parentNode === node) {
+                            resultNodes.push(childNode);
+                        }
                     }
                 }
-            } else {
-                resultNodes = resultNodes.concat(childNodes);
-            }
+                break;
+            case "+":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    parentNode = node.parentNode;
+                    if (!parentNode) { continue; }
+                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.previousElementSibling === node) {
+                            resultNodes.push(childNode);
+                        }
+                    }
+                }
+                break;
+            case "~":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    parentNode = node.parentNode;
+                    if (!parentNode) { continue; }
+                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.parentNode === parentNode && node.compareDocumentPosition(childNode) === 4) {
+                            resultNodes.push(childNode);
+                        }
+                    }
+                }
         }
 
         return Sizzle.uniqueSort(resultNodes);

--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -285,60 +285,11 @@ var ExtendedSelector = (function () { // jshint ignore:line
         if (!simpleNodes || !simpleNodes.length) {
             return resultNodes;
         }
-        var iSimpleNodes = simpleNodes.length;
-        var node, childNodes, iChildNodes, childNode, parentNode;
-        switch (compiledSelector.relation) {
-            case " ":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-                    Array.prototype.push.apply(resultNodes, childNodes);
-                }
-                break;
-            case ">":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.parentNode === node) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
-                break;
-            case "+":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    parentNode = node.parentNode;
-                    if (!parentNode) { continue; }
-                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.previousElementSibling === node) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
-                break;
-            case "~":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    parentNode = node.parentNode;
-                    if (!parentNode) { continue; }
-                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.parentNode === parentNode && node.compareDocumentPosition(childNode) === 4) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
+        var iSimpleNodes = simpleNodes.length; 
+        while (iSimpleNodes--) {
+            var node = simpleNodes[iSimpleNodes];
+            Sizzle(compiledSelector.relation + compiledSelector.complex, node, resultNodes); // jshint ignore:line
         }
-
         return Sizzle.uniqueSort(resultNodes);
     };
 

--- a/test/selector/test-selector.html
+++ b/test/selector/test-selector.html
@@ -26,14 +26,15 @@
         <p class="lead">Use this document as a way to quickly start any new project.<br> All you get is this text and a
             mostly barebones HTML document.</p>
 
-        <div id="test-id-div" i18n="test-attr-i18n" />
-        <div id="test-div" class="test-class test-class-two">
-            <a href="test.html" class="a-test-class a-test-class-two a-test-class-three"/>
-            <h2>
-                <div>
-                    <a href="/test/"><time class="g-time" title=" 8 июля 2016" datetime=" 15:00,  8 июля 2016">15:00</time><br/>adg-test</a>
-                </div>
-            </h2>
+        <div id="test-id-div" i18n="test-attr-i18n">
+            <div id="test-div" class="test-class test-class-two">
+                <a href="test.html" class="a-test-class a-test-class-two a-test-class-three"/>
+                <h2>
+                    <div>
+                        <a href="/test/"><time class="g-time" title=" 8 июля 2016" datetime=" 15:00,  8 июля 2016">15:00</time><br/>adg-test</a>
+                    </div>
+                </h2>
+            </div>
         </div>
     </div>
 

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -133,9 +133,10 @@ QUnit.test( "Test tokenize selector", function(assert) {
 
     selectorText = "div span.className + a[href^='http'] ~ #banner";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
-    assert.equal(compiled.simple, "div");
-    assert.equal(compiled.relation, " ");
-    assert.equal(compiled.complex, "span.className + a[href^='http'] ~ #banner");
+
+    assert.equal(compiled.simple, selectorText);
+    assert.notOk(compiled.relation);
+    assert.notOk(compiled.complex);
 
     selectorText = "#banner div:first-child > div:has(.banner)";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
@@ -143,10 +144,22 @@ QUnit.test( "Test tokenize selector", function(assert) {
     assert.equal(compiled.relation, ">");
     assert.equal(compiled.complex, "div:has(.banner)");
 
+    selectorText = "#banner div:first-child ~ div:has(.banner)";
+    compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.equal(compiled.simple, "#banner div:first-child");
+    assert.equal(compiled.relation, '~');
+    assert.equal(compiled.complex, 'div:has(.banner)');
+
     selectorText = "#banner div:first-child > div > :has(.banner) > div";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
     assert.equal(compiled.simple, "#banner div:first-child > div");
     assert.equal(compiled.relation, ">");
+    assert.equal(compiled.complex, ":has(.banner) > div");
+
+    selectorText = "#banner div:first-child > div + :has(.banner) > div";
+    compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.equal(compiled.simple, "#banner div:first-child > div");
+    assert.equal(compiled.relation, "+");
     assert.equal(compiled.complex, ":has(.banner) > div");
 
     selectorText = "#banner :not(div) div:matches-css(background: blank)";
@@ -193,6 +206,22 @@ QUnit.test( "Test -abp-has and -abp-has-text", function(assert) {
     assert.ok(selector.matches(elements[0]));
 
     selector = new ExtendedSelector('div:-abp-has(div.test-class-two) > .test-class:-abp-contains(adg-test)');
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+});
+
+QUnit.test( "Test + and ~ combinators matching", function(assert) {
+    var selectorText, selector, elements;
+
+    selectorText = "* > p ~ #test-id-div a:contains('adg-test')";
+    selector = new ExtendedSelector(selectorText);
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+
+    selectorText = "* > .lead ~ div:has(a[href^='/t'])";
+    selector = new ExtendedSelector(selectorText);
     elements = selector.querySelectorAll();
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -220,6 +220,12 @@ QUnit.test( "Test + and ~ combinators matching", function(assert) {
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));
 
+    selectorText = "* > div + style:matches-css(display:none) ~ div > *:matches-css-after(content:/y\\st/)"
+    selector = new ExtendedSelector(selectorText);
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+
     selectorText = "* > .lead ~ div:has(a[href^='/t'])";
     selector = new ExtendedSelector(selectorText);
     elements = selector.querySelectorAll();


### PR DESCRIPTION
on `https://www.dobreprogramy.pl/`,
`document.querySelectorAll('* > script + script + *:not(script) + *:not(script) [id]')` returns a node, but
`ExtendedCss.query('* > script + script + *:not(script) + *:not(script) [id]')` does not return a node.