### PR TITLE
Fix sibling combinator

### DIFF
--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -112,7 +112,8 @@ var ExtendedSelector = (function () { // jshint ignore:line
      * Checks if specified token is parenthesis relation
      */
     var isRelationToken = function(token) {
-        return token.type === " " || token.type === ">";
+        var type = token.type;
+        return type === " " || type === ">" || type === '+' || type === '~';
     };
 
     /**
@@ -284,23 +285,58 @@ var ExtendedSelector = (function () { // jshint ignore:line
         if (!simpleNodes || !simpleNodes.length) {
             return resultNodes;
         }
-
         var iSimpleNodes = simpleNodes.length;
-        while (iSimpleNodes--) {
-            var node = simpleNodes[iSimpleNodes];
-            var childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-            if (compiledSelector.relation === ">") {
-                // Filter direct children
-                var iChildNodes = childNodes.length;
-                while (iChildNodes--) {
-                    var childNode = childNodes[iChildNodes];
-                    if (childNode.parentNode === node) {
-                        resultNodes.push(childNode);
+        var node, childNodes, iChildNodes, childNode, parentNode;
+        switch (compiledSelector.relation) {
+            case " ":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
+                    Array.prototype.push.apply(resultNodes, childNodes);
+                }
+                break;
+            case ">":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.parentNode === node) {
+                            resultNodes.push(childNode);
+                        }
                     }
                 }
-            } else {
-                resultNodes = resultNodes.concat(childNodes);
-            }
+                break;
+            case "+":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    parentNode = node.parentNode;
+                    if (!parentNode) { continue; }
+                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.previousElementSibling === node) {
+                            resultNodes.push(childNode);
+                        }
+                    }
+                }
+                break;
+            case "~":
+                while (iSimpleNodes--) {
+                    node = simpleNodes[iSimpleNodes];
+                    parentNode = node.parentNode;
+                    if (!parentNode) { continue; }
+                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
+                    iChildNodes = childNodes.length;
+                    while (iChildNodes--) {
+                        childNode = childNodes[iChildNodes];
+                        if (childNode.parentNode === parentNode && node.compareDocumentPosition(childNode) === 4) {
+                            resultNodes.push(childNode);
+                        }
+                    }
+                }
         }
 
         return Sizzle.uniqueSort(resultNodes);

--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -285,60 +285,11 @@ var ExtendedSelector = (function () { // jshint ignore:line
         if (!simpleNodes || !simpleNodes.length) {
             return resultNodes;
         }
-        var iSimpleNodes = simpleNodes.length;
-        var node, childNodes, iChildNodes, childNode, parentNode;
-        switch (compiledSelector.relation) {
-            case " ":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-                    Array.prototype.push.apply(resultNodes, childNodes);
-                }
-                break;
-            case ">":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    childNodes = Sizzle(compiledSelector.complex, node); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.parentNode === node) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
-                break;
-            case "+":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    parentNode = node.parentNode;
-                    if (!parentNode) { continue; }
-                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.previousElementSibling === node) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
-                break;
-            case "~":
-                while (iSimpleNodes--) {
-                    node = simpleNodes[iSimpleNodes];
-                    parentNode = node.parentNode;
-                    if (!parentNode) { continue; }
-                    childNodes = Sizzle(compiledSelector.complex, parentNode); // jshint ignore:line
-                    iChildNodes = childNodes.length;
-                    while (iChildNodes--) {
-                        childNode = childNodes[iChildNodes];
-                        if (childNode.parentNode === parentNode && node.compareDocumentPosition(childNode) === 4) {
-                            resultNodes.push(childNode);
-                        }
-                    }
-                }
+        var iSimpleNodes = simpleNodes.length; 
+        while (iSimpleNodes--) {
+            var node = simpleNodes[iSimpleNodes];
+            Sizzle(compiledSelector.relation + compiledSelector.complex, node, resultNodes); // jshint ignore:line
         }
-
         return Sizzle.uniqueSort(resultNodes);
     };
 

--- a/lib/extended-css-selector.js
+++ b/lib/extended-css-selector.js
@@ -33,301 +33,326 @@
 
 
 var ExtendedSelector = (function () { // jshint ignore:line
-
-    var PSEUDO_EXTENSIONS_MARKERS = [ ":has", ":contains", ":has-text", ":matches-css" ];
-
-    // Add :matches-css-*() support
-    StylePropertyMatcher.extendSizzle(Sizzle);
-
-    // Add :contains, :has-text, :-abp-contains support
-    Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["-abp-contains"] = Sizzle.selectors.createPseudo(function( text ) {
-        if(/^\s*\/.*\/\s*$/.test(text)) {
-            text = text.trim().slice(1, -1).replace(/\\([\\"])/g, '$1');
-            var regex;
-            try {
-                regex = new RegExp(text);
-            } catch(e) {
-                throw new Error('Invalid argument of :contains pseudo class: ' + text);
-            }
-            return function( elem ) {
-                return regex.test(elem.textContent);
-            };
-        } else {
-            text = text.replace(/\\([\\()[\]"])/g, '$1');
-            return function( elem ) {
-                return elem.textContent.indexOf( text ) > -1;
-            };
-        }
-    });
-
-    // Add :-abp-has support
-    Sizzle.selectors.pseudos["-abp-has"] = Sizzle.selectors.pseudos["has"];
-
-    /**
-     * Complex replacement function. 
-     * Unescapes quote characters inside of an extended selector.
-     * 
-     * @param match     Whole matched string
-     * @param name      Group 1
-     * @param quoteChar Group 2
-     * @param value     Group 3
-     */
-    var evaluateMatch = function (match, name, quoteChar, value) {
-        // Unescape quotes
-        var re = new RegExp("([^\\\\]|^)\\\\" + quoteChar, "g");
-        value = value.replace(re, "$1" + quoteChar);
-        return ":" + name + "(" + value + ")";
-    };
-
-    /**
-     * Checks if specified token is simple and can be used by document.querySelectorAll. 
-     */
-    var isSimpleToken = function (token) {
-
-        if (token.type === "ID" ||
-            token.type === "CLASS" ||
-            token.type === "ATTR" ||
-            token.type === "TAG" ||
-            token.type === "CHILD") {
-            // known simple tokens
-            return true;
-        }
-
-        if (token.type === "PSEUDO") {
-            // check if value contains any of extended pseudo classes
-            var i = PSEUDO_EXTENSIONS_MARKERS.length;
-            while (i--) {
-                if (token.value.indexOf(PSEUDO_EXTENSIONS_MARKERS[i]) >= 0) {
-                    return false;
+    
+        var PSEUDO_EXTENSIONS_MARKERS = [ ":has", ":contains", ":has-text", ":matches-css" ];
+    
+        // Add :matches-css-*() support
+        StylePropertyMatcher.extendSizzle(Sizzle);
+    
+        // Add :contains, :has-text, :-abp-contains support
+        Sizzle.selectors.pseudos["contains"] = Sizzle.selectors.pseudos["has-text"] = Sizzle.selectors.pseudos["-abp-contains"] = Sizzle.selectors.createPseudo(function( text ) {
+            if(/^\s*\/.*\/\s*$/.test(text)) {
+                text = text.trim().slice(1, -1).replace(/\\([\\"])/g, '$1');
+                var regex;
+                try {
+                    regex = new RegExp(text);
+                } catch(e) {
+                    throw new Error('Invalid argument of :contains pseudo class: ' + text);
                 }
-            }
-            return true;
-        }
-
-        // all others aren't simple
-        return false;
-    };
-
-    /**
-     * Checks if specified token is parenthesis relation
-     */
-    var isRelationToken = function(token) {
-        var type = token.type;
-        return type === " " || type === ">" || type === '+' || type === '~';
-    };
-
-    /**
-     * Joins tokens values
-     */
-    var joinTokens = function(selector, relationToken, tokens) {
-        selector = selector || "";
-        if (relationToken) {
-            selector += relationToken.value;
-        }
-
-        for (var i = 0; i < tokens.length; i++) {
-            selector += tokens[i].value;
-        }
-        return selector;
-    };
-
-    /**
-     * Parses selector into two parts:
-     * 1. Simple selector, which can be used by document.querySelectorAll.
-     * 2. Complex selector, which can be used by Sizzle only.
-     * 
-     * @returns object with three fields: simple, complex and relation (and also "selectorText" with source selector)
-     */
-    var tokenizeSelector = function (selectorText) {
-
-        var tokens = Sizzle.tokenize(selectorText);
-        if (tokens.length !== 1) {
-            // Do not optimize complex selectors
-            return {
-                simple: null,
-                relation: null,
-                complex: selectorText,
-                selectorText: selectorText
-            };
-        }
-
-        tokens = tokens[0];
-        var simple = "";
-        var complex = "";
-        
-        // Simple tokens (can be used by document.querySelectorAll)
-        var simpleTokens = [];
-        // Complex tokens (cannot be used at all)
-        var complexTokens = [];
-        var relationToken = null;
-        
-        for (var i = 0; i < tokens.length; i++) {
-            var token = tokens[i];
-
-            if (complexTokens.length > 0 || (!isSimpleToken(token) && !isRelationToken(token))) {
-                // If we meet complex token, all subsequent tokens are considered complex
-                // All previously found simple tokens are also considered complex
-                if (simpleTokens.length > 0) {
-                    Array.prototype.push.apply(complexTokens, simpleTokens);
-                    simpleTokens = [];
-                }
-
-                complexTokens.push(token);
-            } else if (isRelationToken(token)) {
-                // Parenthesis relation token
-                simple = joinTokens(simple, relationToken, simpleTokens);
-                simpleTokens = [];
-
-                // Save relation token (it could be used further)
-                relationToken = token;
+                return function( elem ) {
+                    return regex.test(elem.textContent);
+                };
             } else {
-                // Save to simple tokens collection
-                simpleTokens.push(token);                
+                text = text.replace(/\\([\\()[\]"])/g, '$1');
+                return function( elem ) {
+                    return elem.textContent.indexOf( text ) > -1;
+                };
             }
-        }
-
-        // Finalize building simple and complex selectors
-        if (simpleTokens.length > 0) {
-            simple = joinTokens(simple, relationToken, simpleTokens);
-            relationToken = null;
-        }
-        complex = joinTokens(complex, null, complexTokens);
-
-        if (!simple) {
-            // Nothing to optimize
+        });
+    
+        // Add :-abp-has support
+        Sizzle.selectors.pseudos["-abp-has"] = Sizzle.selectors.pseudos["has"];
+    
+        /**
+         * Complex replacement function. 
+         * Unescapes quote characters inside of an extended selector.
+         * 
+         * @param match     Whole matched string
+         * @param name      Group 1
+         * @param quoteChar Group 2
+         * @param value     Group 3
+         */
+        var evaluateMatch = function (match, name, quoteChar, value) {
+            // Unescape quotes
+            var re = new RegExp("([^\\\\]|^)\\\\" + quoteChar, "g");
+            value = value.replace(re, "$1" + quoteChar);
+            return ":" + name + "(" + value + ")";
+        };
+    
+        /**
+         * Checks if specified token is simple and can be used by document.querySelectorAll. 
+         */
+        var isSimpleToken = function (token) {
+    
+            if (token.type === "ID" ||
+                token.type === "CLASS" ||
+                token.type === "ATTR" ||
+                token.type === "TAG" ||
+                token.type === "CHILD") {
+                // known simple tokens
+                return true;
+            }
+    
+            if (token.type === "PSEUDO") {
+                // check if value contains any of extended pseudo classes
+                var i = PSEUDO_EXTENSIONS_MARKERS.length;
+                while (i--) {
+                    if (token.value.indexOf(PSEUDO_EXTENSIONS_MARKERS[i]) >= 0) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+    
+            // all others aren't simple
+            return false;
+        };
+    
+        /**
+         * Checks if specified token is parenthesis relation
+         */
+        var isRelationToken = function(token) {
+            var type = token.type;
+            return type === " " || type === ">" || type === '+' || type === '~';
+        };
+    
+        var getEasyTokenization = function(selectorText) {
             return {
                 simple: null,
                 relation: null,
                 complex: selectorText,
                 selectorText: selectorText
             };
-        }
+        };
 
-        // Validate simple token
-        try {
-            document.querySelector(simple);
-        } catch (ex) {
-            // Simple token appears to be invalid
+        /**
+         * Parses selector into two parts:
+         * 1. Simple selector, which can be used by document.querySelectorAll.
+         * 2. Complex selector, which is a single compound selector and to be used with Sizzle.
+         * 
+         * @returns object with three fields: simple, complex and relation (and also "selectorText" with source selector)
+         */
+        var tokenizeSelector = function (selectorText) {
+            var tokens = Sizzle.tokenize(selectorText);
+
+            if (tokens.length !== 1) {
+                // Do not optimize complex selectors
+                return getEasyTokenization(selectorText);
+            }
+            tokens = tokens[0];
+
+            // We split selector only when the last compound selector
+            // is the only extended selector.
+            var latestRelationToken = -1;
+            var haveMetComplexToken = false;
+            var iToken, lToken;
+            for (iToken = 0, lToken = tokens.length; iToken < lToken; iToken++) {
+                var token = tokens[iToken];
+                if (isRelationToken(token)) {
+                    if (haveMetComplexToken) {
+                        return getEasyTokenization(selectorText);
+                    } else {
+                        latestRelationToken = iToken;
+                    }
+                } else if (!isSimpleToken(token)) {
+                    haveMetComplexToken = true;
+                }
+            }
+
+            var simple = "";
+            var relation = null;
+            var complex = "";
+
+            if (haveMetComplexToken) {
+                for (iToken = 0; iToken < latestRelationToken; iToken++) {
+                    simple += tokens[iToken].value;
+                }
+                if (iToken > -1) {
+                    relation = tokens[iToken].type;
+                }
+                iToken++;
+                for (; iToken < lToken; iToken++) {
+                    complex += tokens[iToken].value;
+                }
+            } else {
+                simple = selectorText;
+            }
+
+            // Validate simple token
+            try {
+                document.querySelector(simple);
+            } catch(e) {
+                // Simple token appears to be invalid
+                return getEasyTokenization(selectorText);
+            }
             return {
-                simple: null,
-                relation: null,
-                complex: selectorText,
-                selectorText: selectorText
+                simple: simple || null,
+                relation: relation,
+                complex: complex || null,
+                selectorText: selectorText 
             };
-        }
-
-        return {
-            simple: simple,
-            relation: (relationToken === null ? null : relationToken.type),
-            complex: (complex === "" ? null : complex),
-            selectorText: selectorText
-        };
-    };
-
-    /**
-     * Used for pre-processing pseud-classes values (see prepareSelector)
-     */
-    var addQuotes = function(_, c1, c2) { return ':' + c1 + '("' + c2.replace(/["\\]/g, '\\$&') + '")'; };
-
-    /**
-     * Prepares specified selector and compiles it with the Sizzle engine.
-     * Preparation means transforming [-ext-*=""] attributes to pseudo classes.
-     * 
-     * @param selectorText Selector text
-     */
-    var prepareSelector = function (selectorText) {
-        try {
-            // Prepare selector to be compiled with Sizzle
-            // Which means transform [-ext-*=""] attributes to pseudo classes
-            var re = /\[-ext-([a-z-_]+)=(["'])((?:(?=(\\?))\4.)*?)\2\]/g;
-            var str = selectorText.replace(re, evaluateMatch);
-
-            // Sizzle's parsing of pseudo class arguments is buggy on certain circumstances
-            // We support following form of arguments:
-            // 1. for :matches-css, those of a form {propertyName}: /.*/
-            // 2. for :contains, those of a form /.*/
-            // We transform such cases in a way that Sizzle has no ambiguity in parsing arguments.
-            str = str.replace(/\:(matches-css(?:-after|-before)?)\(([a-z-\s]*\:\s*\/(?:\\.|[^\/])*?\/\s*)\)/g, addQuotes);
-            str = str.replace(/:(contains|has-text)\((\s*\/(?:\\.|[^\/])*?\/\s*)\)/g, addQuotes);
-            // Note that we require `/` character in regular expressions to be escaped.
-
-            var compiledSelector = tokenizeSelector(str);
-
-            // Compiles and validates selector
-            // Compilation in Sizzle means that selector will be saved to the inner cache and then reused
-            // Directly compiling unprocessed selectorText can cause problems.
-            // For instance, one of tests in test/test-selector.html fails without this change.
-            // It will fall into the same pitfall we were trying to fix in https://github.com/AdguardTeam/ExtendedCss/issues/23
-            Sizzle.compile(compiledSelector.selectorText);
-
-            if (compiledSelector.complex) {
-                Sizzle.compile(compiledSelector.complex);
-            }
-            return compiledSelector;
-        } catch (ex) {
-            if (typeof console !== 'undefined' && console.error) {
-                console.error('Extended selector is invalid: ' + selectorText);
-            }
-            return null;
-        }
-    };
-
-    /**
-     * Does the complex search (first executes document.querySelectorAll, then Sizzle)
-     * 
-     * @param compiledSelector Compiled selector (simple, complex and relation)
-     */
-    var complexSearch = function(compiledSelector) {
-        var resultNodes = [];
-
-        // First we use simple selector to narrow our search
-        var simpleNodes = document.querySelectorAll(compiledSelector.simple);
-        if (!simpleNodes || !simpleNodes.length) {
-            return resultNodes;
-        }
-        var iSimpleNodes = simpleNodes.length; 
-        while (iSimpleNodes--) {
-            var node = simpleNodes[iSimpleNodes];
-            Sizzle(compiledSelector.relation + compiledSelector.complex, node, resultNodes); // jshint ignore:line
-        }
-        return Sizzle.uniqueSort(resultNodes);
-    };
-
-    // Constructor
-    return function (selectorText) {
-        var compiledSelector = prepareSelector(selectorText);
-
-        // EXPOSE
-        this.compiledSelector = compiledSelector;
-        this.selectorText = (compiledSelector == null ? null : compiledSelector.selectorText);
-
-        /**
-         * Selects all DOM nodes matching this selector.
-         */
-        this.querySelectorAll = function () {
-            if (compiledSelector === null) {
-                // Invalid selector, always return empty array
-                return [];
-            }
-
-            if (!compiledSelector.simple) {
-                // No simple selector applied
-                return Sizzle(compiledSelector.complex); // jshint ignore:line
-            }
-
-            if (!compiledSelector.complex) {
-                // There is no complex selector, so we could simply return it immediately
-                return document.querySelectorAll(compiledSelector.simple);
-            }
-
-            return complexSearch(compiledSelector);
         };
 
         /**
-         * Checks if the specified element matches this selector
+         * Used for pre-processing pseud-classes values (see prepareSelector)
          */
-        this.matches = function (element) {
-            return Sizzle.matchesSelector(element, compiledSelector.selectorText);
+        var addQuotes = function(_, c1, c2) { return ':' + c1 + '("' + c2.replace(/["\\]/g, '\\$&') + '")'; };
+    
+        /**
+         * Prepares specified selector and compiles it with the Sizzle engine.
+         * Preparation means transforming [-ext-*=""] attributes to pseudo classes.
+         * 
+         * @param selectorText Selector text
+         */
+        var prepareSelector = function (selectorText) {
+            try {
+                // Prepare selector to be compiled with Sizzle
+                // Which means transform [-ext-*=""] attributes to pseudo classes
+                var re = /\[-ext-([a-z-_]+)=(["'])((?:(?=(\\?))\4.)*?)\2\]/g;
+                var str = selectorText.replace(re, evaluateMatch);
+    
+                // Sizzle's parsing of pseudo class arguments is buggy on certain circumstances
+                // We support following form of arguments:
+                // 1. for :matches-css, those of a form {propertyName}: /.*/
+                // 2. for :contains, those of a form /.*/
+                // We transform such cases in a way that Sizzle has no ambiguity in parsing arguments.
+                str = str.replace(/\:(matches-css(?:-after|-before)?)\(([a-z-\s]*\:\s*\/(?:\\.|[^\/])*?\/\s*)\)/g, addQuotes);
+                str = str.replace(/:(contains|has-text)\((\s*\/(?:\\.|[^\/])*?\/\s*)\)/g, addQuotes);
+                // Note that we require `/` character in regular expressions to be escaped.
+    
+                var compiledSelector = tokenizeSelector(str);
+    
+                // Compiles and validates selector
+                // Compilation in Sizzle means that selector will be saved to the inner cache and then reused
+                // Directly compiling unprocessed selectorText can cause problems.
+                // For instance, one of tests in test/test-selector.html fails without this change.
+                // It will fall into the same pitfall we were trying to fix in https://github.com/AdguardTeam/ExtendedCss/issues/23
+                Sizzle.compile(compiledSelector.selectorText);
+    
+                if (compiledSelector.complex) {
+                    Sizzle.compile(compiledSelector.complex);
+                }
+                return compiledSelector;
+            } catch (ex) {
+                if (typeof console !== 'undefined' && console.error) {
+                    console.error('Extended selector is invalid: ' + selectorText);
+                }
+                return null;
+            }
         };
-    };
-})();
+
+        /**
+         * Does the complex search (first executes document.querySelectorAll, then Sizzle)
+         * 
+         * @param compiledSelector Compiled selector (simple, complex and relation)
+         */
+        var complexSearch = function(compiledSelector) {
+            var resultNodes = [];
+
+            // First we use simple selector to narrow our search
+            var simpleNodes = document.querySelectorAll(compiledSelector.simple);
+            if (!simpleNodes || !simpleNodes.length) {
+                return resultNodes;
+            }
+            var iSimpleNodes = simpleNodes.length;
+            var node, childNodes, iChildNodes, childNode, parentNode;
+            switch (compiledSelector.relation) {
+                case " ":
+                    while (iSimpleNodes--) {
+                        node = simpleNodes[iSimpleNodes];
+                        Sizzle(compiledSelector.complex, node, resultNodes); // jshint ignore:line
+                    }
+                    break;
+                case ">":
+                    // buffer array
+                    childNodes = [];
+                    while (iSimpleNodes--) {
+                        node = simpleNodes[iSimpleNodes];
+                        Sizzle(compiledSelector.complex, node, childNodes); // jshint ignore:line
+                        iChildNodes = childNodes.length;
+                        while (iChildNodes--) {
+                            childNode = childNodes[iChildNodes];
+                            if (childNode.parentNode === node) {
+                                resultNodes.push(childNode);
+                            }
+                        }
+                        // clears the buffer
+                        childNodes.length = 0;
+                    }
+                    break;
+                case "+":
+                    childNodes = [];
+                    while (iSimpleNodes--) {
+                        node = simpleNodes[iSimpleNodes];
+                        parentNode = node.parentNode;
+                        if (!parentNode) { continue; }
+                        Sizzle(compiledSelector.complex, parentNode, childNodes); // jshint ignore:line
+                        iChildNodes = childNodes.length;
+                        while (iChildNodes--) {
+                            childNode = childNodes[iChildNodes];
+                            if (childNode.previousElementSibling === node) {
+                                resultNodes.push(childNode);
+                            }
+                        }
+                        childNodes.length = 0;
+                    }
+                    break;
+                case "~":
+                    childNodes = [];
+                    while (iSimpleNodes--) {
+                        node = simpleNodes[iSimpleNodes];
+                        parentNode = node.parentNode;
+                        if (!parentNode) { continue; }
+                        Sizzle(compiledSelector.complex, parentNode, childNodes); // jshint ignore:line
+                        iChildNodes = childNodes.length;
+                        while (iChildNodes--) {
+                            childNode = childNodes[iChildNodes];
+                            if (childNode.parentNode === parentNode && node.compareDocumentPosition(childNode) === 4) {
+                                resultNodes.push(childNode);
+                            }
+                        }
+                        childNodes.length = 0;
+                    }
+            }
+
+            return Sizzle.uniqueSort(resultNodes);
+        };
+        
+        // Constructor
+        return function (selectorText) {
+            var compiledSelector = prepareSelector(selectorText);
+    
+            // EXPOSE
+            this.compiledSelector = compiledSelector;
+            this.selectorText = (compiledSelector == null ? null : compiledSelector.selectorText);
+    
+            /**
+             * Selects all DOM nodes matching this selector.
+             */
+            this.querySelectorAll = function () {
+                if (compiledSelector === null) {
+                    // Invalid selector, always return empty array
+                    return [];
+                }
+    
+                if (!compiledSelector.simple) {
+                    // No simple selector applied
+                    return Sizzle(compiledSelector.complex); // jshint ignore:line
+                }
+    
+                if (!compiledSelector.complex) {
+                    // There is no complex selector, so we could simply return it immediately
+                    return document.querySelectorAll(compiledSelector.simple);
+                }
+    
+                return complexSearch(compiledSelector);
+            };
+    
+            /**
+             * Checks if the specified element matches this selector
+             */
+            this.matches = function (element) {
+                return Sizzle.matchesSelector(element, compiledSelector.selectorText);
+            };
+        };
+    })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extended-css",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Module for applying CSS styles with extended selection properties.",
   "main": "extended-css.js",
   "directories": {

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -14,7 +14,7 @@ var testPerformance = function(selector, assert) {
     var msg = 'Elapsed: ' + elapsed + ' ms\n';
     msg += 'Count: ' + LOOP_COUNT + '\n';
     msg += 'Average: ' + elapsed / LOOP_COUNT + ' ms';
-
+    console.log(msg);
     assert.ok(resultOk, msg);
 };
 

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -14,7 +14,6 @@ var testPerformance = function(selector, assert) {
     var msg = 'Elapsed: ' + elapsed + ' ms\n';
     msg += 'Count: ' + LOOP_COUNT + '\n';
     msg += 'Average: ' + elapsed / LOOP_COUNT + ' ms';
-    console.log(msg);
     assert.ok(resultOk, msg);
 };
 

--- a/test/selector/test-selector.html
+++ b/test/selector/test-selector.html
@@ -26,14 +26,15 @@
         <p class="lead">Use this document as a way to quickly start any new project.<br> All you get is this text and a
             mostly barebones HTML document.</p>
 
-        <div id="test-id-div" i18n="test-attr-i18n" />
-        <div id="test-div" class="test-class test-class-two">
-            <a href="test.html" class="a-test-class a-test-class-two a-test-class-three"/>
-            <h2>
-                <div>
-                    <a href="/test/"><time class="g-time" title=" 8 июля 2016" datetime=" 15:00,  8 июля 2016">15:00</time><br/>adg-test</a>
-                </div>
-            </h2>
+        <div id="test-id-div" i18n="test-attr-i18n">
+            <div id="test-div" class="test-class test-class-two">
+                <a href="test.html" class="a-test-class a-test-class-two a-test-class-three"/>
+                <h2>
+                    <div>
+                        <a href="/test/"><time class="g-time" title=" 8 июля 2016" datetime=" 15:00,  8 июля 2016">15:00</time><br/>adg-test</a>
+                    </div>
+                </h2>
+            </div>
         </div>
     </div>
 

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -133,9 +133,10 @@ QUnit.test( "Test tokenize selector", function(assert) {
 
     selectorText = "div span.className + a[href^='http'] ~ #banner";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
-    assert.equal(compiled.simple, "div");
-    assert.equal(compiled.relation, " ");
-    assert.equal(compiled.complex, "span.className + a[href^='http'] ~ #banner");
+
+    assert.equal(compiled.simple, selectorText);
+    assert.notOk(compiled.relation);
+    assert.notOk(compiled.complex);
 
     selectorText = "#banner div:first-child > div:has(.banner)";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
@@ -143,10 +144,22 @@ QUnit.test( "Test tokenize selector", function(assert) {
     assert.equal(compiled.relation, ">");
     assert.equal(compiled.complex, "div:has(.banner)");
 
+    selectorText = "#banner div:first-child ~ div:has(.banner)";
+    compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.equal(compiled.simple, "#banner div:first-child");
+    assert.equal(compiled.relation, '~');
+    assert.equal(compiled.complex, 'div:has(.banner)');
+
     selectorText = "#banner div:first-child > div > :has(.banner) > div";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
     assert.equal(compiled.simple, "#banner div:first-child > div");
     assert.equal(compiled.relation, ">");
+    assert.equal(compiled.complex, ":has(.banner) > div");
+
+    selectorText = "#banner div:first-child > div + :has(.banner) > div";
+    compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.equal(compiled.simple, "#banner div:first-child > div");
+    assert.equal(compiled.relation, "+");
     assert.equal(compiled.complex, ":has(.banner) > div");
 
     selectorText = "#banner :not(div) div:matches-css(background: blank)";
@@ -193,6 +206,22 @@ QUnit.test( "Test -abp-has and -abp-has-text", function(assert) {
     assert.ok(selector.matches(elements[0]));
 
     selector = new ExtendedSelector('div:-abp-has(div.test-class-two) > .test-class:-abp-contains(adg-test)');
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+});
+
+QUnit.test( "Test + and ~ combinators matching", function(assert) {
+    var selectorText, selector, elements;
+
+    selectorText = "* > p ~ #test-id-div a:contains('adg-test')";
+    selector = new ExtendedSelector(selectorText);
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+
+    selectorText = "* > .lead ~ div:has(a[href^='/t'])";
+    selector = new ExtendedSelector(selectorText);
     elements = selector.querySelectorAll();
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -220,6 +220,12 @@ QUnit.test( "Test + and ~ combinators matching", function(assert) {
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));
 
+    selectorText = "* > div + style:matches-css(display:none) ~ div > *:matches-css-after(content:/y\\st/)"
+    selector = new ExtendedSelector(selectorText);
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
+
     selectorText = "* > .lead ~ div:has(a[href^='/t'])";
     selector = new ExtendedSelector(selectorText);
     elements = selector.querySelectorAll();

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -154,21 +154,13 @@ QUnit.test( "Test tokenize selector", function(assert) {
     assert.notOk(compiled.simple);
     assert.notOk(compiled.relation);
     assert.equal(compiled.complex, selectorText);
-/*
-    assert.equal(compiled.simple, "#banner div:first-child > div");
-    assert.equal(compiled.relation, ">");
-    assert.equal(compiled.complex, ":has(.banner) > div");
-*/
+
     selectorText = "#banner div:first-child > div + :has(.banner) > div";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
     assert.notOk(compiled.simple);
     assert.notOk(compiled.relation);
     assert.equal(compiled.complex, selectorText);
-/*
-    assert.equal(compiled.simple, "#banner div:first-child > div");
-    assert.equal(compiled.relation, "+");
-    assert.equal(compiled.complex, ":has(.banner) > div");
-*/
+
     selectorText = "#banner :not(div) div:matches-css(background: blank)";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
     assert.equal(compiled.simple, "#banner :not(div)");

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -230,4 +230,10 @@ QUnit.test( "Test + and ~ combinators matching", function(assert) {
     elements = selector.querySelectorAll();
     assert.equal(1, elements.length);
     assert.ok(selector.matches(elements[0]));
+
+    selectorText = "* > .lead + div:has(a[href^='/t'])";
+    selector = new ExtendedSelector(selectorText);
+    elements = selector.querySelectorAll();
+    assert.equal(1, elements.length);
+    assert.ok(selector.matches(elements[0]));
 });

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -133,7 +133,6 @@ QUnit.test( "Test tokenize selector", function(assert) {
 
     selectorText = "div span.className + a[href^='http'] ~ #banner";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
-
     assert.equal(compiled.simple, selectorText);
     assert.notOk(compiled.relation);
     assert.notOk(compiled.complex);
@@ -152,16 +151,24 @@ QUnit.test( "Test tokenize selector", function(assert) {
 
     selectorText = "#banner div:first-child > div > :has(.banner) > div";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.notOk(compiled.simple);
+    assert.notOk(compiled.relation);
+    assert.equal(compiled.complex, selectorText);
+/*
     assert.equal(compiled.simple, "#banner div:first-child > div");
     assert.equal(compiled.relation, ">");
     assert.equal(compiled.complex, ":has(.banner) > div");
-
+*/
     selectorText = "#banner div:first-child > div + :has(.banner) > div";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
+    assert.notOk(compiled.simple);
+    assert.notOk(compiled.relation);
+    assert.equal(compiled.complex, selectorText);
+/*
     assert.equal(compiled.simple, "#banner div:first-child > div");
     assert.equal(compiled.relation, "+");
     assert.equal(compiled.complex, ":has(.banner) > div");
-
+*/
     selectorText = "#banner :not(div) div:matches-css(background: blank)";
     compiled = new ExtendedSelector(selectorText).compiledSelector;
     assert.equal(compiled.simple, "#banner :not(div)");


### PR DESCRIPTION
on https://www.dobreprogramy.pl/,
`document.querySelectorAll('* > script + script + *:not(script) + *:not(script) [id]')` returns a node, but
`ExtendedCss.query('* > script + script + *:not(script) + *:not(script) [id]')` does not return a node.