### PR TITLE
Resolving coding style issues for #55

### DIFF
--- a/lib/extended-css.js
+++ b/lib/extended-css.js
@@ -19,10 +19,11 @@
 /**
  * Extended css class
  *
- * @param styleSheet
+ * @param {string} styleSheet CSS stylesheet text
+ * @param {Array.<HTMLElement>} propertyFilterIgnoreStyleNodes A list of stylesheet nodes that should be ignored by the StyleObserver (":properties" matching object)
  * @constructor
  */
-var ExtendedCss = function (styleSheet) { // jshint ignore:line
+var ExtendedCss = function (styleSheet, propertyFilterIgnoreStyleNodes) { // jshint ignore:line
     var rules = [];
     var affectedElements = [];
     var domObserved;
@@ -215,9 +216,6 @@ var ExtendedCss = function (styleSheet) { // jshint ignore:line
     var apply = function () {
         applyRules();
         observe();
-        if (StyleObserver.initialize(ExtendedCss.ignoredSheets) === false) {
-            StyleObserver = null; // jshint ignore:line
-        }
 
         if (document.readyState !== "complete") {
             document.addEventListener("DOMContentLoaded", applyRules);
@@ -236,6 +234,9 @@ var ExtendedCss = function (styleSheet) { // jshint ignore:line
             revertStyle(obj);
         }
     };
+
+    // Let StyleObserver know which stylesheets should not be used for :properties matching
+    StyleObserver.setIgnoredStyleNodes(propertyFilterIgnoreStyleNodes);
     
     // First of all parse the stylesheet
     rules = ExtendedCssParser.parseCss(styleSheet);
@@ -252,7 +253,6 @@ var ExtendedCss = function (styleSheet) { // jshint ignore:line
 ExtendedCss.query = function(selectorText) {
     var now = 'now' in performance ? performance.now.bind(performance) : Date.now;
     var selector = new ExtendedSelector(selectorText);
-    StyleObserver.initialize(ExtendedCss.ignoredSheets);
     var start = now();
     var matched = selector.querySelectorAll();
     var end = now();

--- a/lib/style-observer.js
+++ b/lib/style-observer.js
@@ -14,23 +14,37 @@
  * limitations under the License.
  */
 
-/* global utils, CSSRule, console */
+/* global utils, CSSRule */
 
- /**
-  * `:properties(propertyFilter)` pseudo class support works by looking up
-  * selectors that are applied to styles whose style declaration matches
-  * arguments passed to the pseudo class.
-  * `sheetToFilterSelectorMap` contains a data mapping (stylesheets, filter)
-  * -> selector.
-  */
-var StyleObserver = (function() { // jshint ignore:line
+/**
+ * `:properties(propertyFilter)` pseudo class support works by looking up
+ * selectors that are applied to styles whose style declaration matches
+ * arguments passed to the pseudo class.
+ * `sheetToFilterSelectorMap` contains a data mapping (stylesheets, filter)
+ * -> selector.
+ */
+var StyleObserver = (function () { // jshint ignore:line
 
     // Utility functions
     var styleSelector = 'style';
 
+    /**
+     * A set of stylesheet nodes that should be ignored by the StyleObserver.
+     * This field is essential in the case of AdGuard products that add regular stylesheets
+     * in order to apply CSS rules
+     * 
+     * @type {Set.<HTMLElement>}
+     */
+    var ignoredStyleNodes;
+
+    /** 
+     * The flag is used for the StyleObserver lazy initialization
+     */
+    var initialized = false;
+
     var searchTree = function (node, selector) {
         if (node.nodeType !== Node.ELEMENT_NODE) { return; }
-        var nodes =  node.querySelectorAll(selector);
+        var nodes = node.querySelectorAll(selector);
         if (node[utils.matchesPropertyName](selector)) {
             nodes = Array.prototype.slice.call(nodes);
             nodes.push(node);
@@ -43,7 +57,7 @@ var StyleObserver = (function() { // jshint ignore:line
         if (href === null) { return true; }
         return utils.isSameOrigin(href, location, document.domain);
     };
-    
+
     /**
      * 'rel' attribute is a ASCII-whitespace separated list of keywords.
      * {@link https://html.spec.whatwg.org/multipage/links.html#linkTypes}
@@ -84,7 +98,7 @@ var StyleObserver = (function() { // jshint ignore:line
     };
 
     // Mutation handler functions
-    var styleModHandler = function(mutations) {
+    var styleModHandler = function (mutations) {
         if (mutations.length) {
             for (let mutation of mutations) {
                 let target;
@@ -104,7 +118,7 @@ var StyleObserver = (function() { // jshint ignore:line
         examineStylesScheduler.run();
         invalidateScheduler.run();
     };
-    var styleAdditionHandler = function(mutations) {
+    var styleAdditionHandler = function (mutations) {
         var hasPendingStyles = false;
         for (var mutation of mutations) {
             var addedNodes = mutation.addedNodes,
@@ -136,7 +150,7 @@ var StyleObserver = (function() { // jshint ignore:line
         examineStylesScheduler.run();
         invalidateScheduler.run();
     };
-    
+
     var collectLoadedLinkStyle = function (evt) {
         var target = evt.target;
         if (!eventTargetIsLinkStylesheet(target)) { return; }
@@ -157,6 +171,7 @@ var StyleObserver = (function() { // jshint ignore:line
     var styleAdditionObserver;
     var styleModObserver;
     var observing = false;
+
     var observeStyle = function () {
         if (observing) { return; }
         observing = true;
@@ -171,6 +186,7 @@ var StyleObserver = (function() { // jshint ignore:line
         document.addEventListener('load', collectLoadedLinkStyle, true);
         document.addEventListener('error', discardErroredLinkStyle, true);
     };
+
     var observeStyleModification = function (styleNode) {
         if (utils.MutationObserver) {
             styleModObserver.observe(styleNode, { childList: true, subtree: true, characterData: true });
@@ -202,6 +218,7 @@ var StyleObserver = (function() { // jshint ignore:line
         }
         document.removeEventListener('load', collectLoadedLinkStyle);
         document.removeEventListener('error', discardErroredLinkStyle);
+        observing = false;
     };
 
     /**
@@ -217,8 +234,8 @@ var StyleObserver = (function() { // jshint ignore:line
     var sheetToFilterSelectorMap;
 
     var anyStyleWasUpdated; // A boolean flag to be accessed in `examineStyles`
-                            // and `readStyleSheetContent` calls.
-    var examinePendingStyles = function() {
+    // and `readStyleSheetContent` calls.
+    var examinePendingStyles = function () {
         // console.log('StyleObserver: examiningPendingStyles');
         anyStyleWasUpdated = false;
         pendingStyles.forEach(readStyleNodeContent);
@@ -232,7 +249,7 @@ var StyleObserver = (function() { // jshint ignore:line
     var examineStylesScheduler = new utils.AsyncWrapper(examinePendingStyles);
 
     /** @param {HTMLStyleElement} styleNode */
-    var readStyleNodeContent = function(styleNode) {
+    var readStyleNodeContent = function (styleNode) {
         var sheet = styleNode.sheet;
         if (!sheet) {
             // This can happen when an appended style or a loaded linked stylesheet is
@@ -246,8 +263,12 @@ var StyleObserver = (function() { // jshint ignore:line
      * @param {CSSStyleSheet} styleSheet
      */
     var readStyleSheetContent = function (styleSheet) {
-        if (!isSameOriginStyle(styleSheet)) { return; }
-        if (ignoredSheets.has(styleSheet)) { return; }
+        if (!isSameOriginStyle(styleSheet)) { 
+            return; 
+        }
+        if (isIgnored(styleSheet.ownerNode)) {
+            return;
+        }
         var rules = styleSheet.cssRules;
         var map = Object.create(null);
         for (let rule of rules) {
@@ -268,7 +289,7 @@ var StyleObserver = (function() { // jshint ignore:line
                 anyStyleWasUpdated = true;
                 // Strips out psedo elements
                 // https://adblockplus.org/en/filters#elemhide-emulation
-                var selectorText = rule.selectorText.replace(/::(?:after|before)/,'');
+                var selectorText = rule.selectorText.replace(/::(?:after|before)/, '');
 
                 var filter = parsedFilter.filter;
 
@@ -309,17 +330,16 @@ var StyleObserver = (function() { // jshint ignore:line
     };
 
     /**
-     * @type {Set<CSSStyleSheet>}
-     */
-    var ignoredSheets;
-
-    /**
      * A main function, to be used in Sizzle matcher.
      * returns a selector text that is
      * @param {string} filter
      * @return {string} a selector.
      */
     var getSelector = function (filter) {
+
+        // Lazy-initialize the StyleObserver
+        initialize();
+
         // getSelector will be triggered via mutation observer callbacks
         // and we assume that those are already throttled.
         examineStylesScheduler.runImmediately();
@@ -373,7 +393,7 @@ var StyleObserver = (function() { // jshint ignore:line
             getSelectorCache = Object.create(null);
             getSelectorCacheHasData = false;
         }
-        
+
     };
     var invalidateScheduler = new utils.AsyncWrapper(invalidateCache, 0);
 
@@ -397,6 +417,15 @@ var StyleObserver = (function() { // jshint ignore:line
             re: re
         });
         registeredFiltersMap[filter] = true;
+
+        /**
+         * Mark StyleObserver as not initialized right after
+         * the new property filter is registered
+         */
+        initialized = false;
+
+        // It is also necessary to invalidate getSelectorCache right away
+        invalidateCache();
     };
 
     /**
@@ -409,7 +438,7 @@ var StyleObserver = (function() { // jshint ignore:line
      * @return {boolean} Whether it had to be initialized. If it returns false,
      * We can clear StyleObserver from the memory.
      */
-    var initialize = function (sheetsToIgnore) {
+    var initialize = function () {
         if (initialized) {
             return;
         }
@@ -422,39 +451,36 @@ var StyleObserver = (function() { // jshint ignore:line
 
         sheetToFilterSelectorMap = new utils.WeakMap();
         pendingStyles = new utils.Set();
-        ignoredSheets = new utils.Set(sheetsToIgnore);
         observeStyle();
+
         // Initial processing
-        console.time("StyleObserver initial processing");
         var sheets = document.styleSheets;
         for (let sheet of sheets) {
             readStyleSheetContent(sheet);
-            if (sheet.ownerNode.nodeName === 'STYLE') {
+            if (sheet.ownerNode.nodeName === 'STYLE' && !isIgnored(sheet.ownerNode)) {
                 observeStyleModification(sheet.ownerNode);
             }
         }
-        console.timeEnd("StyleObserver initial processing");
         return true;
     };
-    var initialized = false;
 
     /**
      * Exported method to disconnect existing mutation observers and remove
      * event listeners, clear collections and caches.
      */
     var clear = function () {
-        if (!initialized) { return; }
         initialized = false;
+        invalidateCache();
         disconnectObservers();
         pendingStyles.clear();
-        sheetToFilterSelectorMap = pendingStyles = ignoredSheets = null;
+        sheetToFilterSelectorMap = pendingStyles = ignoredStyleNodes = null;
     };
 
     /**
      * Creates a new pseudo-class and registers it in Sizzle
      */
-    var extendSizzle = function(Sizzle) {
-        Sizzle.selectors.pseudos["properties"] = Sizzle.selectors.pseudos["-abp-properties"] = Sizzle.selectors.createPseudo(function(propertyFilter) {
+    var extendSizzle = function (Sizzle) {
+        Sizzle.selectors.pseudos["properties"] = Sizzle.selectors.pseudos["-abp-properties"] = Sizzle.selectors.createPseudo(function (propertyFilter) {
             registerStylePropertyFilter(propertyFilter);
             return function (element) {
                 var selector = getSelector(propertyFilter);
@@ -464,10 +490,37 @@ var StyleObserver = (function() { // jshint ignore:line
         });
     };
 
+    /**
+     * Checks if stylesheet node is in the list of ignored
+     * @param {HTMLElement} styleNode Stylesheet owner node
+     */
+    var isIgnored = function (styleNode) {
+        return ignoredStyleNodes && ignoredStyleNodes.has(styleNode);
+    };
+
+    /**
+     * Sets a list of stylesheet nodes that must be ignored by the StyleObserver.
+     * 
+     * @param {Array.<HTMLElement>} styleNodesToIgnore A list of stylesheet nodes. Can be empty or null.
+     */
+    var setIgnoredStyleNodes = function (styleNodesToIgnore) {
+
+        // StyleObserver should be fully reinitialized after that
+        if (initialized || observing) {
+            clear();
+        }
+
+        if (styleNodesToIgnore) {
+            ignoredStyleNodes = new utils.Set(styleNodesToIgnore);
+        } else {
+            ignoredStyleNodes = null;
+        }
+    };
+
     return {
-        initialize: initialize,
         clear: clear,
         extendSizzle: extendSizzle,
-        getSelector: getSelector
+        getSelector: getSelector,
+        setIgnoredStyleNodes: setIgnoredStyleNodes
     };
 })();

--- a/lib/style-property-matcher.js
+++ b/lib/style-property-matcher.js
@@ -49,11 +49,11 @@ var StylePropertyMatcher = (function (window, document) { // jshint ignore:line
         return value.replace(re, "url($1)");
     };
 
-
     var getComputedStyle = window.getComputedStyle.bind(window);
     if (useFallback) {
         var getMatchedCSSRules = window.getMatchedCSSRules.bind(window);
     }
+
     /**
      * There is a known issue in Safari browser:
      * getComputedStyle(el, ":before") is empty if element is not visible.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
- /* global console */
- 
+/* global console */
+
 const utils = {};
 
 utils.MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
@@ -34,7 +34,7 @@ utils.pseudoArgToRegex = function (regexSrc, flag) {
 /**
  * Helper function for creating regular expression from a url filter rule syntax.
  */
-utils.createURLRegex = (function() { // jshint ignore:line
+utils.createURLRegex = (function () { // jshint ignore:line
     // Constants
     var regexConfiguration = {
         maskStartUrl: "||",
@@ -93,14 +93,14 @@ utils.createURLRegex = (function() { // jshint ignore:line
      * @param {string} str
      * @return {RegExp}
      */
-    var createRegexText = function(str) {
+    var createRegexText = function (str) {
         var regex = escapeRegExp(str);
 
         if (startsWith(regex, regexConfiguration.maskStartUrl)) {
             regex = regex.substring(0, regexConfiguration.maskStartUrl.length) +
                 replaceAll(regex.substring(regexConfiguration.maskStartUrl.length, regex.length - 1), "\|", "\\|") +
                 regex.substring(regex.length - 1);
-        } else if (startsWith(regex, regexConfiguration.maskPipe)){
+        } else if (startsWith(regex, regexConfiguration.maskPipe)) {
             regex = regex.substring(0, regexConfiguration.maskPipe.length) +
                 replaceAll(regex.substring(regexConfiguration.maskPipe.length, regex.length - 1), "\|", "\\|") +
                 regex.substring(regex.length - 1);
@@ -163,8 +163,8 @@ utils.isSameOrigin = function (url_A, location_B, domain_B) {
 /**
  * A helper class to throttle function calls with setTimeout and requestAnimationFrame.
  */
-utils.AsyncWrapper = (function() {
-    
+utils.AsyncWrapper = (function () {
+
     /**
      * PhantomJS passes a wrong timestamp to the requestAnimationFrame callback and that breaks the AsyncWrapper logic
      * https://github.com/ariya/phantomjs/issues/14832
@@ -183,12 +183,12 @@ utils.AsyncWrapper = (function() {
         this.callback = callback;
         this.throttle = throttle;
         this.wrappedCallback = this.wrappedCallback.bind(this);
-        if (this.wrappedAsapCallback) { 
+        if (this.wrappedAsapCallback) {
             this.wrappedAsapCallback = this.wrappedAsapCallback.bind(this);
         }
     }
     /** @private */
-    AsyncWrapper.prototype.wrappedCallback = function(ts) {
+    AsyncWrapper.prototype.wrappedCallback = function (ts) {
         this.lastRun = isNumber(ts) ? ts : perf.now();
         this.rAFid = this.timerId = undefined;
         this.callback();
@@ -200,7 +200,7 @@ utils.AsyncWrapper = (function() {
     /**
      * Schedules a function call before the next animation frame.
      */
-    AsyncWrapper.prototype.run = function() {
+    AsyncWrapper.prototype.run = function () {
         if (this.hasPendingCallback()) {
             // There is a pending execution scheduled.
             return;
@@ -218,7 +218,7 @@ utils.AsyncWrapper = (function() {
      * Schedules a function call in the most immenent microtask.
      * This cannot be canceled.
      */
-    AsyncWrapper.prototype.runAsap = utils.MutationObserver ? function() {
+    AsyncWrapper.prototype.runAsap = utils.MutationObserver ? function () {
         cAF(this.rAFid);
         clearTimeout(this.timerId);
         /**
@@ -250,7 +250,7 @@ utils.AsyncWrapper = (function() {
     /**
      * Runs scheduled execution immediately, if there were any.
      */
-    AsyncWrapper.prototype.runImmediately = function() {
+    AsyncWrapper.prototype.runImmediately = function () {
         if (this.hasPendingCallback()) {
             cAF(this.rAFid);
             clearTimeout(this.timerId);
@@ -259,7 +259,7 @@ utils.AsyncWrapper = (function() {
         }
     };
 
-    AsyncWrapper.now = function() {
+    AsyncWrapper.now = function () {
         return perf.now();
     };
 
@@ -271,61 +271,70 @@ utils.AsyncWrapper = (function() {
  */
 utils.defineProperty = Object.defineProperty;
 
-utils.WeakMap = typeof WeakMap !== 'undefined' ? WeakMap : (function() {
+utils.WeakMap = typeof WeakMap !== 'undefined' ? WeakMap : (function () {
     /** Originally based on {@link https://github.com/Polymer/WeakMap} */
     var counter = Date.now() % 1e9;
 
-    var WeakMap = function() {
-      this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
+    var WeakMap = function () {
+        this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
     };
 
     WeakMap.prototype = {
-      set: function(key, value) {
-        var entry = key[this.name];
-        if (entry && entry[0] === key) {
-          entry[1] = value;
-        } else {
-          utils.defineProperty(key, this.name, {value: [key, value], writable: true});
+        set: function (key, value) {
+            var entry = key[this.name];
+            if (entry && entry[0] === key) {
+                entry[1] = value;
+            } else {
+                utils.defineProperty(key, this.name, { value: [key, value], writable: true });
+            }
+            return this;
+        },
+        get: function (key) {
+            var entry;
+            return (entry = key[this.name]) && entry[0] === key ?
+                entry[1] : undefined;
+        },
+        delete: function (key) {
+            var entry = key[this.name];
+            if (!entry) {
+                return false;
+            }
+            var hasValue = entry[0] === key;
+            entry[0] = entry[1] = undefined;
+            return hasValue;
+        },
+        has: function (key) {
+            var entry = key[this.name];
+            if (!entry) {
+                return false;
+            }
+            return entry[0] === key;
         }
-        return this;
-      },
-      get: function(key) {
-        var entry;
-        return (entry = key[this.name]) && entry[0] === key ?
-            entry[1] : undefined;
-      },
-      delete: function(key) {
-        var entry = key[this.name];
-        if (!entry) {
-            return false;
-        }
-        var hasValue = entry[0] === key;
-        entry[0] = entry[1] = undefined;
-        return hasValue;
-      },
-      has: function(key) {
-        var entry = key[this.name];
-        if (!entry) {
-            return false;
-        }
-        return entry[0] === key;
-      }
     };
 
     return WeakMap;
 })();
 
-utils.Set = typeof Set !== 'undefined' ? Set : (function() {
+utils.Set = typeof Set !== 'undefined' ? Set : (function () {
     var counter = Date.now() % 1e9;
     /**
      * A polyfill which covers only the basic usage.
      * Only supports methods that are supported in IE11.
      * {@link https://docs.microsoft.com/en-us/scripting/javascript/reference/set-object-javascript}
      * Assumes that 'key's are all objects, not primitives such as a number.
+     * 
+     * @param {Array} items Initial items in this set
      */
-    var Set = function () {
+    var Set = function (items) {
         this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
         this.keys = [];
+
+        if (items && items.length) {
+            var iItems = items.length;
+            while (iItems--) {
+                this.add(items[iItems]);
+            }
+        }
     };
 
     Set.prototype = {
@@ -345,24 +354,24 @@ utils.Set = typeof Set !== 'undefined' ? Set : (function() {
         has: function (key) {
             return isNumber(key[this.name]);
         },
-        clear: function() {
+        clear: function () {
             this.keys.forEach(function (key) {
                 key[this.name] = undefined;
             });
             this.keys.length = 0;
         },
-        forEach: function(cb) {
+        forEach: function (cb) {
             var that = this;
-            this.keys.forEach(function(value) {
+            this.keys.forEach(function (value) {
                 cb(value, value, that);
             });
         }
     };
 
     utils.defineProperty(Set.prototype, 'size', {
-        get: function() {
+        get: function () {
             // Skips holes.
-            return this.keys.reduce(function(acc) {
+            return this.keys.reduce(function (acc) {
                 return acc + 1;
             }, 0);
         }
@@ -374,7 +383,7 @@ utils.Set = typeof Set !== 'undefined' ? Set : (function() {
 /**
  * Vendor-specific Element.prototype.matches
  */
-utils.matchesPropertyName = (function() {
+utils.matchesPropertyName = (function () {
     var props = ['matches', 'matchesSelector', 'mozMatchesSelector', 'msMatchesSelector', 'oMatchesSelector', 'webkitMatchesSelector'];
 
     for (var i = 0; i < 6; i++) {
@@ -387,7 +396,7 @@ utils.matchesPropertyName = (function() {
 /** 
  * Safely calls console.error if it's present
  */
-utils.logError = function(message) {
+utils.logError = function (message) {
     if (typeof console !== 'undefined' && console.error) {
         console.error(message);
     }

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -1,6 +1,6 @@
 var LOOP_COUNT = 10000;
 
-var testPerformance = function(selector, assert) {
+var testPerformance = function (selector, assert) {
     var startTime = new Date().getTime();
     var iCount = LOOP_COUNT;
     var resultOk = true;
@@ -17,11 +17,11 @@ var testPerformance = function(selector, assert) {
     assert.ok(resultOk, msg);
 };
 
-QUnit.test("Tokenize performance", function(assert) {
+QUnit.test("Tokenize performance", function (assert) {
 
     var selectorText = "#case5 > div:not([style^=\"min-height:\"]) > div[id][data-uniqid^=\"toolkit-\"]:not([data-bem]):not([data-mnemo])[-ext-has='a[href^=\"https://an.yandex.\"]>img']";
     var startTime = new Date().getTime();
-    
+
     var resultOk = true;
     var iCount = LOOP_COUNT;
     while (iCount--) {
@@ -37,64 +37,59 @@ QUnit.test("Tokenize performance", function(assert) {
     assert.ok(resultOk, msg);
 });
 
-QUnit.test("Test simple selector", function(assert) {
+QUnit.test("Test simple selector", function (assert) {
     var selector = {
-        querySelectorAll: function() {
+        querySelectorAll: function () {
             return document.querySelectorAll(".container #case1 div div");
         }
     }
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 1. :has performance", function(assert) {
+QUnit.test("Case 1. :has performance", function (assert) {
     var selectorText = ".container #case1 div div:has(.banner)";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 2. :contains performance", function(assert) {
+QUnit.test("Case 2. :contains performance", function (assert) {
     var selectorText = ".container #case2 div div:contains(Block this)";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 3. :matches-css performance", function(assert) {
+QUnit.test("Case 3. :matches-css performance", function (assert) {
     var selectorText = ".container #case3 div div:matches-css(background-image: about:blank)";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 4. :has and :contains composite performance", function(assert) {
+QUnit.test("Case 4. :has and :contains composite performance", function (assert) {
     var selectorText = ".container #case4 div div:has(.banner:contains(Block this))";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 5. complicated selector", function(assert) {
+QUnit.test("Case 5. complicated selector", function (assert) {
     // https://github.com/AdguardTeam/ExtendedCss/issues/25
-    
+
     var selectorText = "#case5 > div:not([style^=\"min-height:\"]) > div[id][data-uniqid^=\"toolkit-\"]:not([data-bem]):not([data-mnemo])[-ext-has='a[href^=\"https://an.yandex.\"]>img']";
     var selector = new ExtendedSelector(selectorText);
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 6.1. :properties selector", function(assert) {
+QUnit.test("Case 6.1. :properties selector", function (assert) {
 
     var selectorText = 'div[id^="case6-"]:has(div[class]:properties(content:*test))';
     var selector = new ExtendedSelector(selectorText);
-
-    // TODO: Should be initialized implicitly in the ExtendedSelector
-    StyleObserver.initialize();
     testPerformance(selector, assert);
 });
 
 
-QUnit.test("Case 6.2. :properties selector wihout seed", function(assert) {
+QUnit.test("Case 6.2. :properties selector wihout seed", function (assert) {
 
     var selectorText = '[id^="case6-"]:has([class]:properties(content:*test))';
     var selector = new ExtendedSelector(selectorText);
 
-    // TODO: Should be initialized implicitly in the ExtendedSelector
-    StyleObserver.initialize();
     testPerformance(selector, assert);
 });

--- a/test/selector/test-selector.html
+++ b/test/selector/test-selector.html
@@ -74,6 +74,13 @@
         #test-properties-has-child { background: #111; }
     </style>
 
+    <div id="test-properties-ignored-stylesheets">
+        <div id="test-properties-ignored-stylesheets-background"></div>
+    </div>
+    <style id="ignored-stylesheet">
+        #test-properties-ignored-stylesheets-background { background: #333; }
+    </style>
+
 </div>
 
 <script src="../qunit/qunit-2.0.1.js"></script>

--- a/test/selector/test-selector.js
+++ b/test/selector/test-selector.js
@@ -258,8 +258,6 @@ QUnit.test( "Test :properties", function(assert) {
     });
     window.selectors = selectors;
 
-    assert.ok(StyleObserver.initialize() !== false);
-
     var elements, tempStyle;
 
     elements = selectors[0].querySelectorAll();
@@ -321,6 +319,25 @@ QUnit.test( "Test :properties", function(assert) {
     });
 
     rAF(done);
+});
+
+QUnit.test( "Test :properties with ignored stylesheets", function(assert) {
+
+    var selector = new ExtendedSelector(":properties(background-color: rgb\(51, 51, 51\))");
+
+    // First test the regular selector
+    var elements = selector.querySelectorAll();
+    assert.equal(elements.length, 1);
+    assert.equal(elements[0], window['test-properties-ignored-stylesheets-background']);
+
+    // Now set the ignored stylsheets and re-test
+    var ignoredStyleNodes = document.querySelectorAll("#ignored-stylesheet");
+    assert.ok(ignoredStyleNodes.length);
+    StyleObserver.setIgnoredStyleNodes(ignoredStyleNodes);
+
+    // The matching style was in the ignored stylesheet so nothing is selected
+    elements = selector.querySelectorAll();
+    assert.equal(elements.length, 0);
 });
 
 function containsElement(element, list) {


### PR DESCRIPTION
Talking about coding style issues from this comment:
https://github.com/AdguardTeam/ExtendedCss/issues/55#issuecomment-364058745

1. StyleObserver.initialize is no more exposed as a public API method;
2. StyleObserver is now initialized lazily allowing to create ExtendedSelector dynamically whenever we want to;
3. Got rid of ExtendedCss.ignoredSheets property. Ignored style nodes are now passed via the ExtendedCss constructor;
4. It seems that ignoredSheets never worked as intended. Fixed that and added a unit test to verify that it works properly;