### PR TITLE
Added profiler to performance tests #55

### DIFF
--- a/lib/sizzle.patched.js
+++ b/lib/sizzle.patched.js
@@ -1603,14 +1603,24 @@ var TokenSorter = (function() {
 		"PSEUDO": 60
 	};
 
+	var getTokenCompareValue = function(token) {
+
+		// [SIZZLE_PATCH #7]: Demonstrating how we can implement properties reverse search
+		// Search the code for SIZZLE_PATCH to find the other parts of it
+		// TODO: TEMPORARY, JUST A DEMONSTRATION
+		if (token.type === "PSEUDO" && Expr.find[":" + token.matches[0]]) {
+			return TOKEN_TYPES_VALUES["CLASS"] - 1;
+		}
+
+		return TOKEN_TYPES_VALUES[token.type];
+	};
+
 	/** 
 	 * A function that defines the sort order.
 	 * Returns a value lesser than 0 if "left" is less than "right".
 	 */
 	var compareFunction = function(left, right) {
-		var leftValue = TOKEN_TYPES_VALUES[left.type];
-		var rightValue = TOKEN_TYPES_VALUES[right.type];
-		return leftValue - rightValue;
+		return getTokenCompareValue(left) - getTokenCompareValue(right);
 	};
 
 	/**
@@ -2307,6 +2317,28 @@ select = Sizzle.select = function( selector, context, results, seed ) {
 			if ( Expr.relative[ (type = token.type) ] ) {
 				break;
 			}
+
+			// [SIZZLE_PATCH #7]: Demonstrating how we can implement properties reverse search
+			// Search the code for SIZZLE_PATCH to find the other parts of it
+			// TODO: TEMPORARY, JUST A DEMONSTRATION
+			if (token.type === "PSEUDO") {
+				var pseudoFindType = ":" + token.matches[0];
+				var pseudoFind = Expr.find[pseudoFindType];
+				
+				if (pseudoFind) {
+					seed = pseudoFind(token.matches[1], context);
+					tokens.splice( i, 1 );
+					selector = seed.length && toSelector( tokens );					
+
+					if ( !selector ) {
+						push.apply( results, seed );
+						return results;
+					}
+
+					break;	
+				}
+			}
+
 			if ( (find = Expr.find[ type ]) ) {
 				// Search, expanding context for leading sibling combinators
 				if ( (seed = find(

--- a/lib/style-observer.js
+++ b/lib/style-observer.js
@@ -462,6 +462,15 @@ var StyleObserver = (function() { // jshint ignore:line
                 return element[utils.matchesPropertyName](selector);
             };
         });
+
+        // [SIZZLE_PATCH #7]: Demonstrating how we can implement properties reverse search
+        // Search the code for SIZZLE_PATCH to find the other parts of it
+        // TODO: TEMPORARY, JUST A DEMONSTRATION
+        Sizzle.selectors.find[":properties"] = function(propertyFilter, context) {
+            let selector = StyleObserver.getSelector(propertyFilter);
+            if (selector.length === 0) { return; }
+            return context.querySelectorAll(selector);
+        };
     };
 
     return {

--- a/test/performance/profiler.js
+++ b/test/performance/profiler.js
@@ -1,0 +1,106 @@
+/**
+ * A very simple profiler.
+ * Use it to wrap a function and record all the function calls.
+ */
+var Profiler = (function () {
+
+    /**
+     * Contains all the information about functions being profiled
+     */
+    var perfCounters = {};
+
+    /**
+     * Creates an empty performance counters object
+     */
+    var createPerformanceCounter = function (name) {
+        return {
+            /** Counter name */
+            name: name,
+            /** Total count of calls */
+            count: 0,
+            /** Total time elapsed (ms) */
+            totalElapsed: 0,
+            /** Avg elapsed per call (ms) */
+            averageElapsed: 0,
+            /** Min elapsed on a call (ms) */
+            minElapsed: null,
+            /** Max elapsed on a call (ms) */
+            maxElapsed: null,
+            /** Exceptions thrown */
+            errors: 0
+        };
+    };
+
+    /**
+     * Wraps the specified function in order to measure its performance
+     * 
+     * @param {*} func function to wrap
+     * @param {*} name profile/function name
+     * @returns a wrapped function. Every call of that wrapped function is to be recorded
+     */
+    var profile = function (func, name) {
+
+        return function () {
+
+            var startTime = performance.now();
+            // Calling the original function
+            // TODO: Catch exception and count errors
+            var returnVal = func.apply(this, arguments);
+            var elapsed = performance.now() - startTime;
+
+            // Getting or creating the functions perf counter
+            var perfCounter = perfCounters[name];
+            if (!perfCounter) {
+                perfCounter = createPerformanceCounter(name);
+                perfCounters[name] = perfCounter;
+            }
+
+            // Incrementing it
+            perfCounter.count++;
+            perfCounter.totalElapsed += elapsed;
+            perfCounter.averageElapsed = perfCounter.totalElapsed / perfCounter.count;
+            if (perfCounter.minElapsed === null || perfCounter.minElapsed > elapsed) {
+                perfCounter.minElapsed = elapsed;
+            }
+            if (perfCounter.maxElapsed === null || perfCounter.maxElapsed < elapsed) {
+                perfCounter.maxElapsed = elapsed;
+            }
+
+            return returnVal;
+        };
+    };
+
+    /**
+     * Prints all the recorded performance counters data to the console
+     */
+    var print = function () {
+        for (var name in perfCounters) {
+            if (perfCounters.hasOwnProperty(name)) {
+                var perfCounter = perfCounters[name];
+                console.log(JSON.stringify(perfCounter, null, 4));
+            }
+        }
+    };
+
+    /** 
+     * Gets all the recorded performance counters
+     */
+    var getCounters = function() {
+        return perfCounters;
+    };
+
+    /**
+     * Clears all the recorded data
+     */
+    var clear = function () {
+        perfCounters = {};
+    };
+
+    // Expose
+    return {
+        profile: profile,
+        print: print,
+        clear: clear,
+        getCounters: getCounters
+    };
+})();

--- a/test/performance/test-performance.html
+++ b/test/performance/test-performance.html
@@ -88,6 +88,7 @@
 		<script src="../../dist/style-observer.js"></script>
 		<script src="../../dist/extended-css-selector.js"></script>
 		<script src="../../dist/extended-css.js"></script>
+		<script src="profiler.js"></script>
 		<script src="test-performance.js"></script>
 </body>
 

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -140,3 +140,10 @@ QUnit.test("Case 6.2. :properties selector wihout seed", function(assert) {
     StyleObserver.initialize();
     testPerformance(selector, assert);
 });
+
+QUnit.test("Case 6.3. :properties selector with necessary reverse search", function(assert) {
+
+    var selectorText = 'div:properties(content:*test)';
+    var selector = new ExtendedSelector(selectorText);
+    testPerformance(selector, assert);
+});

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -1,6 +1,39 @@
 var LOOP_COUNT = 10000;
+var PROFILER_PSEUDO_PREFIX = "Sizzle.selectors.pseudo.";
 
+/** 
+ * Wraps some important functions in order to measure their performance.
+ */
+(function() {
+
+    for (var key in Sizzle.selectors.pseudos) {
+        var pseudoFunction = Sizzle.selectors.pseudos[key];
+
+        // Using createPseudo is crucial so that Sizzle could detect that
+        // it's a custom pseudo created with a "new"-style syntax
+        var profilingFunction = Sizzle.selectors.createPseudo((function(pseudoFunction, pseudoName) {
+            return function() {
+                var pseudoMatcher = pseudoFunction.apply(this, arguments);
+                return Profiler.profile(pseudoMatcher, PROFILER_PSEUDO_PREFIX + pseudoName);
+            };
+        })(pseudoFunction, key));
+
+        Sizzle.selectors.pseudos[key] = profilingFunction;
+    }
+
+    utils.AsyncWrapper.prototype.runAsap = Profiler.profile(utils.AsyncWrapper.prototype.runAsap, "AsyncWrapper.prototype.runAsap");
+    utils.AsyncWrapper.prototype.runImmediately = Profiler.profile(utils.AsyncWrapper.prototype.runImmediately, "AsyncWrapper.prototype.runImmediately");
+})();
+
+/**
+ * Calls querySelectorAll for "LOOP_COUNT" times and returns an object
+ * with the performance counters recorded by the {@link Profiler} instance.
+ * 
+ * @param {string} selector Selector to test
+ * @param {*} assert QUnit assert object
+ */
 var testPerformance = function(selector, assert) {
+    Profiler.clear();
     var startTime = new Date().getTime();
     var iCount = LOOP_COUNT;
     var resultOk = true;
@@ -14,7 +47,10 @@ var testPerformance = function(selector, assert) {
     var msg = 'Elapsed: ' + elapsed + ' ms\n';
     msg += 'Count: ' + LOOP_COUNT + '\n';
     msg += 'Average: ' + elapsed / LOOP_COUNT + ' ms';
+    Profiler.print();
     assert.ok(resultOk, msg);
+
+    return Profiler.getCounters();
 };
 
 QUnit.test("Tokenize performance", function(assert) {
@@ -49,7 +85,13 @@ QUnit.test("Test simple selector", function(assert) {
 QUnit.test("Case 1. :has performance", function(assert) {
     var selectorText = ".container #case1 div div:has(.banner)";
     var selector = new ExtendedSelector(selectorText);
-    testPerformance(selector, assert);
+    var counters = testPerformance(selector, assert);
+
+    var hasPerfCounter = counters[PROFILER_PSEUDO_PREFIX + "has"];
+    // TODO: Make it work
+    // This is temporary commented out.
+    // In v1.0.9 it worked properly, but in the master branch the ":has" perf counter it called three times more
+    // assert.equal(hasPerfCounter.count, LOOP_COUNT);
 });
 
 QUnit.test("Case 2. :contains performance", function(assert) {

--- a/test/performance/test-performance.js
+++ b/test/performance/test-performance.js
@@ -141,9 +141,22 @@ QUnit.test("Case 6.2. :properties selector wihout seed", function(assert) {
     testPerformance(selector, assert);
 });
 
-QUnit.test("Case 6.3. :properties selector with necessary reverse search", function(assert) {
+QUnit.test("Case 6.3. :properties selector with simple reverse search", function(assert) {
 
     var selectorText = 'div:properties(content:*test)';
     var selector = new ExtendedSelector(selectorText);
+
+    // TODO: Should be removed after merge with #65
+    StyleObserver.initialize();
+    testPerformance(selector, assert);
+});
+
+QUnit.test("Case 6.4. :properties selector with complex reverse search", function(assert) {
+
+    var selectorText = 'div:has(:properties(content:*test))';
+    var selector = new ExtendedSelector(selectorText);
+
+    // TODO: Should be removed after merge with #65
+    StyleObserver.initialize();    
     testPerformance(selector, assert);
 });


### PR DESCRIPTION
A simple profiler lets us address the issue explained in this comment: https://github.com/AdguardTeam/ExtendedCss/issues/55#issuecomment-366243417

The point is that while running a performance test we should count the number of calls of our custom pseudo functions and that will let us avoid making performance worse than it was.

**This PR does not address performance issues, but it can be helpful while resolving point 2 from https://github.com/AdguardTeam/ExtendedCss/issues/55#issuecomment-364058745 (slowdown compared to 1.0.9**